### PR TITLE
Fix git:// repositories

### DIFF
--- a/GitLink.py
+++ b/GitLink.py
@@ -59,11 +59,24 @@ class GitlinkCommand(sublime_plugin.TextCommand):
 
         # need to get username from full url
 
-        # Get username and repository
-        if remote_name != 'codebasehq':
-            source, user, repo = git_config.replace(".git", "").replace("https://", "").split("/")
+        # Get username and repository (& also project for codebasehq)
+        if ':' in git_config:
+            # SSH repository
+            if remote_name == 'codebasehq':
+                # format is codebasehq.com:{user}/{project}/{repo}.git
+                domain, user, project, repo = git_config.replace(".git", "").replace(":", "/").split("/")
+            else:
+                # format is {domain}:{user}/{repo}.git
+                domain, user, repo = git_config.replace(".git", "").replace(":", "/").split("/")
         else:
-           user, project, repo = git_config.replace(".git", "").replace("https://", "").split("/")
+            # HTTP repository
+            if remote_name == 'codebasehq':
+                # format is {user}.codebasehq.com/{project}/{repo}.git
+                domain, project, repo = git_config.replace(".git", "").split("/")
+                user = domain.split('.', 1)[0] # user is first segment of domain
+            else:
+                # format is {domain}/{user}/{repo}.git
+                domain, user, repo = git_config.replace(".git", "").split("/")
 
         # Find top level repo in current dir structure
         remote_path = self.getoutput("git rev-parse --show-prefix")
@@ -72,10 +85,10 @@ class GitlinkCommand(sublime_plugin.TextCommand):
         branch = self.getoutput("git rev-parse --abbrev-ref HEAD")
 
         # Build the URL
-        if remote_name != 'codebasehq':
-            url = remote['url'].format(user, repo, branch, remote_path, filename)
-        else:
+        if remote_name == 'codebasehq':
             url = remote['url'].format(user, project, repo, branch, remote_path, filename)
+        else:
+            url = remote['url'].format(user, repo, branch, remote_path, filename)
 
         if(args['line']):
             row = self.view.rowcol(self.view.sel()[0].begin())[0] + 1

--- a/GitLink.py
+++ b/GitLink.py
@@ -39,18 +39,23 @@ class GitlinkCommand(sublime_plugin.TextCommand):
         # Find the repo
         git_config_path = self.getoutput("git remote show origin -n")
 
-        p = re.compile(r"(.+@)*([\w\d\.]+):(.*)")
+        # Determine git URL which may be either HTTPS or SSH form
+        # (i.e. https://domain/user/repo or git@domain:user/repo)
+        #
+        # parts[0][2] will contain 'domain/user/repo' or 'domain:user/repo'
+        #
+        # see https://regex101.com/r/pZ3tN3/2 & https://regex101.com/r/iS5tQ4/2
+        p = re.compile(r"(.+: )*([\w\d\.]+)[:|@]/?/?(.*)")
         parts = p.findall(git_config_path)
-        site_name = parts[0][2]  # github.com or bitbucket.org, whatever
+        git_config = parts[0][2]
 
         remote_name = 'github'
-        if 'bitbucket' in site_name:
+        if 'bitbucket' in git_config:
             remote_name = 'bitbucket'
-        if 'codebasehq.com' in site_name:
+        if 'codebasehq.com' in git_config:
             remote_name = 'codebasehq'
         remote = REMOTE_CONFIG[remote_name]
 
-        git_config = parts[0][2]
 
         # need to get username from full url
 


### PR DESCRIPTION
This PR fixes #6.

Remote git repositories can be of the form https://domain/user/repo or git@domain:user/repo, so update the regular expression to look for either type. I created https://regex101.com/r/pZ3tN3/2 & https://regex101.com/r/iS5tQ4/2 to work this out.

I've also updated the logic to extract details from the `git_config` parameter as the information is in different places based on the type of git repository.

The format for non-codebasehq repositories is:
SSH: `{example.com}:{user}/{repo}.git`
HTTP: `{example.com}/{user}/{repo}.git`

The codebasehq format is slightly different as we need the project and the user name is in a different place:
SSH: `codebasehq.com:{user}/{project}/{repo}.git`
HTTP: `{user}.codebasehq.com/{project}/{repo}.git`

Finally I swapped the `if` test for codebasehq to a positive check to make it easier to read.

