### PR TITLE
Allow Generating Permanent Links (referencing git commit hashes in the URL instead of just branch names)

### DIFF
--- a/GitLink.py
+++ b/GitLink.py
@@ -82,7 +82,7 @@ class GitlinkCommand(sublime_plugin.TextCommand):
         remote_path = self.getoutput("git rev-parse --show-prefix")
 
         # Find the current revision
-        rev_type = self.view.settings.get('gitlink_revision_type', 'branch')
+        rev_type = self.view.settings().get('gitlink_revision_type', 'branch')
         if rev_type == 'branch':
             git_rev = self.getoutput("git rev-parse --abbrev-ref HEAD")
         elif rev_type == 'commithash':

--- a/GitLink.py
+++ b/GitLink.py
@@ -81,14 +81,18 @@ class GitlinkCommand(sublime_plugin.TextCommand):
         # Find top level repo in current dir structure
         remote_path = self.getoutput("git rev-parse --show-prefix")
 
-        # Find the current branch
-        branch = self.getoutput("git rev-parse --abbrev-ref HEAD")
+        # Find the current revision
+        rev_type = self.view.settings.get('gitlink_revision_type', 'branch')
+        if rev_type == 'branch':
+            git_rev = self.getoutput("git rev-parse --abbrev-ref HEAD")
+        elif rev_type == 'commithash':
+            git_rev = self.getoutput("git rev-parse HEAD")
 
         # Build the URL
         if remote_name == 'codebasehq':
-            url = remote['url'].format(user, project, repo, branch, remote_path, filename)
+            url = remote['url'].format(user, project, repo, git_rev, remote_path, filename)
         else:
-            url = remote['url'].format(user, repo, branch, remote_path, filename)
+            url = remote['url'].format(user, repo, git_rev, remote_path, filename)
 
         if(args['line']):
             region = self.view.sel()[0]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # GitLink
 Sublime Text plugin to derive <http://github.com>, <http://bitbucket.org> or <http://codebasehq.com> URLs to files in your project. No more traversing your file structure finding the file you are working on.
 
-Written by Ryan Scherf : <http://ryan.sc> - <http://twitter.com/ryanscherf>  
+Written by Ryan Scherf : <http://ryan.sc> - <http://twitter.com/ryanscherf>
 CodebaseHQ support by <http://iRonin.pl>
 
 ## How it works
@@ -29,14 +29,15 @@ To install manually, you can clone Git repository directly:
 * `git clone git@github.com:rscherf/GitLink.git`
 * Restart Sublime Text
 
+# Configuration
+To switch to generating permanent links that reference a git commit hash instead of branch name, add `"gitlink_revision_type": "commithash"` to your Preferences.sublime-settings file.
+
 # Contribute
 GitHub and Sublime Text are powerful; I know all of you can make this way better than me.
 
 1. Fork/clone the repository
 2. Add whatever you'd like
 3. Submit a Pull Request
-
-
 
 # Copyright
 1. Star the Github repository


### PR DESCRIPTION
This feature allows GitLink to behave the same way as GitHub's appreciated "copy permalink" feature by generating links like `https://github.com/rscherf/GitLink/blob/e117c1e4d6a05ad5163bfe28fac9282f9db048b3/GitLink.py#L42` instead of just `https://github.com/rscherf/GitLink/blob/master/GitLink.py#L42`.

I have placed this change behind a settings flag, to make this new behavior opt-in.

Note: I think the superior way to implement settings flags with Sublime Text plugins is to make a plugin-specific settings file, as some other plugins do, instead of reading from the global settings, as this PR does. I don't know how to do that though, and don't really have time to look into it. Even though this PR is not quite perfect in this way I decided that instead of keeping this feature just to myself that I should upload a pull request for it, so others can benefit. :) Please feel free to improve this PR to do so if you know how.

Thank you! 



