### PR TITLE
Fix GitHub line param separator

### DIFF
--- a/GitLink.py
+++ b/GitLink.py
@@ -10,7 +10,7 @@ REMOTE_CONFIG = {
         'url': 'https://github.com/{0}/{1}/blob/{2}/{3}{4}',
         'blame_url': 'https://github.com/{0}/{1}/blame/{2}/{3}{4}',
         'line_param': '#L',
-        'line_param_sep': ':'
+        'line_param_sep': '-L'
     },
     'bitbucket': {
         'url': 'https://bitbucket.org/{0}/{1}/src/{2}/{3}{4}',


### PR DESCRIPTION
GitHub's multiline URL params looks like this: `#L12-L13`, not `#L12:13`, e.g.:

before:
https://github.com/ushuz/GitLink/blob/31d0d2646c970dd5dae9f19f839aa2438a290560/GitLink.py#L12:13

after:
https://github.com/ushuz/GitLink/blob/31d0d2646c970dd5dae9f19f839aa2438a290560/GitLink.py#L12-L13