### PR TITLE
Add default remote and fix settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ The easiest is to install using [Package control](https://sublime.wbond.net/).
 
 To install manually, you can clone the Git repository directly:
 * Mac:
-  * `cd ~/Library/Application Support/Sublime Text 3/Packages/`
+  * `cd ~/Library/Application Support/Sublime Text/Packages/`
 * Linux:
-  * `cd ~/.config/sublime-text-3/Packages`
+  * `cd ~/.config/sublime-text/Packages`
 * `git clone git@github.com:rscherf/GitLink.git`
 * Restart Sublime Text
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,11 @@ Right click anywhere within the file you are currently editing. Your cursor posi
 # Installation
 The easiest is to install using [Package control](https://sublime.wbond.net/).
 
-To install manually, you can clone Git repository directly:
-* `cd ~/Library/Application Support/Sublime Text 2/Packages/`
+To install manually, you can clone the Git repository directly:
+* Mac:
+  * `cd ~/Library/Application Support/Sublime Text 3/Packages/`
+* Linux:
+  * `cd ~/.config/sublime-text-3/Packages`
 * `git clone git@github.com:rscherf/GitLink.git`
 * Restart Sublime Text
 


### PR DESCRIPTION
This patch makes three changes:

* Adds a fallback remote for branches that don't have one set yet (see #32)
* Fixes the settings not being picked up (see line comments for further details)
* Updates the readme for Sublime Text 3 and adds Linux install info