### PR TITLE
Make GitLink.py robust to repo names containing slash

### DIFF
--- a/GitLink.py
+++ b/GitLink.py
@@ -114,12 +114,12 @@ class GitlinkCommand(sublime_plugin.TextCommand):
             # HTTP repository
             if hosting_name == 'codebasehq':
                 # format is {user}.codebasehq.com/{project}/{repo}.git
-                domain, project, repo = remote.split("/")
+                domain, project, repo = remote.split("/", 2)
                 # user is first segment of domain
                 user, domain = domain.split('.', 1)
             else:
                 # format is {domain}/{user}/{repo}.git
-                domain, user, repo = remote.split("://")[-1].split("/")
+                domain, user, repo = remote.split("://")[-1].split("/", 2)
                 project = None
 
         # Find top level repo in current dir structure


### PR DESCRIPTION
This is a fix for the following error:
```pytb
  File "/Applications/Sublime Text.app/Contents/MacOS/Lib/python33/sublime_plugin.py", line 1431, in run_
    return self.run(edit, **args)
  File "/Users/david/Library/Application Support/Sublime Text/Installed Packages/GitLink.sublime-package/GitLink.py", line 122, in run
ValueError: too many values to unpack (expected 3)
```

With a GitLab repo that contains a slash. This is due to the group concept:

The pattern:
```
https://gitlab.com/<org>/<group>/<subgroup>/<repo>
```

Where group and subgroup are optional. having the `<group>/<subgroup>/<repo>` part in the repo variable should make the plugin work for this pattern.