### PR TITLE
Add Azure DevOps

### DIFF
--- a/GitLink.sublime-settings
+++ b/GitLink.sublime-settings
@@ -63,6 +63,7 @@
         "\\bradicle\\b": "radicle",
 
         // Specific sites
+        "\\bdev\\.azure\\.com$": "azure",
         "^codeberg\\.org$": "forgejo",
         "^git\\.sr\\.ht$": "sourcehut",
         "^git\\.kernel\\.org$": "cgit",
@@ -85,6 +86,16 @@
                 "start": "#ln",
                 // "separator": ":",
             },
+        },
+        "azure": {
+            "urls": {
+                "source": "https://{domain}/{owner}/{project}/_git/{repo}?version={revision}&path=/{file}",
+                "blame": "https://{domain}/{owner}/{project}/_git/{repo}?version={revision}&path=/{file}&_a=blame",
+            },
+            // "line_params": {
+            //     "start": "#L",
+            //     "separator": "-",
+            // },
         },
         "bitbucket": {
             "urls": {

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Repository hosts are listed alphabetically.
 
 [Arch Linux][][^gitlab],
 [Assembla][],
+[Azure][] (unverified),
 [Bitbucket][],
 [Codebase][],
 [Codeberg][][^forgejo],
@@ -181,6 +182,7 @@ I know all of you can make this way better than me.
 
 [arch linux]: https://gitlab.archlinux.org
 [assembla]: https://get.assembla.com
+[azure]: https://azure.microsoft.com/en-us/products/devops/
 [bitbucket]: https://bitbucket.org
 [cgit]: https://git.zx2c4.com/cgit/about/
 [codebase]: https://codebasehq.com

--- a/gitlink/RepositoryParser.py
+++ b/gitlink/RepositoryParser.py
@@ -55,6 +55,13 @@ class RepositoryParser(object):
             self.owner = None
             self.repo_name = split_path[0]
 
+        elif self.host_type == 'azure':
+            self.domain = re.sub(r'ssh\.', '', self.domain)
+            if re.match(r'^v\d$', split_path[0]):
+                split_path = split_path[1:]
+            self.owner = split_path[0]
+            self.project = split_path[1]
+
         elif self.host_type == 'cgit':
             if re.search(r'\bsavannah\b', self.domain):
                 self.domain = re.sub(r'^(?:git\.|https\.)?git', 'cgit.git', self.domain)
@@ -105,11 +112,21 @@ class RepositoryParser(object):
 
     def _get_formatted_url(self, fmt_id, file, revision, line_start=0, line_end=0):
         rev = revision
-        if self.host_type == 'forgejo':
+
+        ### Extra rules for specific hosts ####################################
+
+        if self.host_type == 'azure':
+            if self.rev_type == 'abbrev':
+                # GB for Git Branch?
+                rev = 'GB' + revision
+
+        elif self.host_type == 'forgejo':
             if self.rev_type == 'abbrev':
                 rev = 'branch/' + revision
             elif self.rev_type == 'commithash':
                 rev = 'commit/' + revision
+
+        ### End extra host rules ##############################################
 
         url = self.host_template['urls'][fmt_id].format(
             domain=self.domain,

--- a/tests/test_RepositoryParser.py
+++ b/tests/test_RepositoryParser.py
@@ -70,6 +70,42 @@ class RepoParserAssembla(TestCase):
                          parse_result.get_blame_url('README.md', 'master', 5, 7))
 
 
+class RepoParserAzure(TestCase):
+
+    def test_azure_ssh(self):
+        parse_result = RepositoryParser('git@ssh.dev.azure.com:v3/organization/project/repo')
+        self.assertEqual('ssh', parse_result.scheme)
+        self.assertEqual('dev.azure.com', parse_result.domain)
+        self.assertEqual('git', parse_result.logon_user)
+        self.assertEqual(None, parse_result.logon_password)
+        self.assertEqual('organization', parse_result.owner)
+        self.assertEqual('project', parse_result.project)
+        self.assertEqual('repo', parse_result.repo_name)
+        self.assertEqual('https://dev.azure.com/organization/project/_git/repo?version=GBmaster&path=/README.md',
+                         parse_result.get_source_url('README.md', 'master'))
+        self.assertEqual('https://dev.azure.com/organization/project/_git/repo?version=GBmaster&path=/README.md',
+                         parse_result.get_source_url('README.md', 'master', 5))
+        self.assertEqual('https://dev.azure.com/organization/project/_git/repo?version=GBmaster&path=/README.md',
+                         parse_result.get_source_url('README.md', 'master', 5, 7))
+
+    def test_azure_https(self):
+        parse_result = RepositoryParser('https://logon_user:PAT@dev.azure.com/organization/project/_git/repo')
+        self.assertEqual('https', parse_result.scheme)
+        self.assertEqual('dev.azure.com', parse_result.domain)
+        self.assertEqual('logon_user', parse_result.logon_user)
+        self.assertEqual('PAT', parse_result.logon_password)
+        self.assertEqual('organization', parse_result.owner)
+        self.assertEqual('project', parse_result.project)
+        self.assertEqual('repo', parse_result.repo_name)
+        self.assertEqual('logon_user', parse_result.logon_user)
+        self.assertEqual('https://dev.azure.com/organization/project/_git/repo?version=GBmaster&path=/README.md',
+                         parse_result.get_source_url('README.md', 'master'))
+        self.assertEqual('https://dev.azure.com/organization/project/_git/repo?version=GBmaster&path=/README.md',
+                         parse_result.get_source_url('README.md', 'master', 5))
+        self.assertEqual('https://dev.azure.com/organization/project/_git/repo?version=GBmaster&path=/README.md',
+                         parse_result.get_source_url('README.md', 'master', 5, 7))
+
+
 class RepoParserBitbucket(TestCase):
 
     def test_ssh(self):


### PR DESCRIPTION
Unverified URLs. I couldn't find a public project to test.

- The blame is just a guess.
- I couldn't even guess at a line number format.
- There may need to be some special behavior for commit SHA like there is for branches.