### PR TITLE
Fix SSH port parsing and support multi-level paths for all hosts

### DIFF
--- a/gitlink/RepositoryParser.py
+++ b/gitlink/RepositoryParser.py
@@ -41,26 +41,21 @@ class RepositoryParser(object):
         if re.match(r'^git@', git_url):
             git_url = 'ssh://' + git_url
         if 'ssh://' in git_url:
-            git_url = re.sub(r'\b:(?=[\w~])', '/', git_url, count=1)
+            git_url = re.sub(r'\b:(?!\d)(?=[\w~])', '/', git_url, count=1)
         parsed_url = urlparse(git_url)
         self._pr = parsed_url
 
         self.scheme = parsed_url.scheme
-        self.logon_user = None
-        self.logon_password = None
-        try:
-            self.logon_user, self.domain = parsed_url.netloc.split('@')
-            if ':' in self.logon_user:
-                self.logon_user, self.logon_password = self.logon_user.split(':')
-        except:
-            self.domain = parsed_url.netloc
+        self.logon_user = parsed_url.username
+        self.logon_password = parsed_url.password
+        self.domain = parsed_url.hostname or parsed_url.netloc
 
         # Look up the host template
         self.host_type, self.host_template = self._get_repo_host()
 
         path = re.sub(r'\.git$', '', parsed_url.path)
         split_path = path.split('/')[1:]
-        self.owner = split_path[0]
+        self.owner = '/'.join(split_path[:-1])
         self.repo_name = split_path[-1]
         self.project = None
 
@@ -95,6 +90,7 @@ class RepositoryParser(object):
             self.project = '/'.join(split_path[:-1])
 
         elif self.host_type == 'codebase':
+            self.owner = split_path[0]
             self.project = split_path[1]
             if 'http' in self.scheme:
                 self.owner = self.domain.split('.')[0]
@@ -105,22 +101,18 @@ class RepositoryParser(object):
             self.owner = split_path[-2]
             self.repo_name = split_path[-1]
 
-        elif self.host_type == 'gitlab':
-            self.owner = '/'.join(split_path[:-1])
-
         elif self.host_type == 'phabricator':
+            self.owner = split_path[0]
             self.repo_name = split_path[1]
 
         elif self.host_type == 'radicle':
             self.owner = None
 
         elif self.host_type == 'rhodecode':
-            if self.scheme == 'ssh':
-                split_path = split_path[1:]
             self.owner = None
-            self.repo_name = split_path[0]
+            self.repo_name = split_path[-1]
 
-        elif self.host_type == 'sourceforge' and self.owner == 'p':
+        elif self.host_type == 'sourceforge' and split_path[0] == 'p':
             self.owner = split_path[1]
 
         ### End extra host rules ##############################################

--- a/tests/test_RepositoryParser.py
+++ b/tests/test_RepositoryParser.py
@@ -863,6 +863,27 @@ class RepoParserGitHub(TestCase):
         self.assertEqual('https://github.com/user/repo/blame/master/README.md?plain=1#L5-L7',
                          parse_result.get_blame_url('README.md', 'master', 5, 7))
 
+    def test_ssh_with_port(self):
+        parse_result = RepositoryParser('ssh://git@github.com:2222/user/repo.git')
+        self.assertEqual('ssh', parse_result.scheme)
+        self.assertEqual('github.com', parse_result.domain)
+        self.assertEqual('git', parse_result.logon_user)
+        self.assertEqual(None, parse_result.logon_password)
+        self.assertEqual('user', parse_result.owner)
+        self.assertEqual('repo', parse_result.repo_name)
+        self.assertEqual('https://github.com/user/repo/blob/master/README.md',
+                         parse_result.get_source_url('README.md', 'master'))
+        self.assertEqual('https://github.com/user/repo/blob/master/README.md?plain=1#L5',
+                         parse_result.get_source_url('README.md', 'master', 5))
+        self.assertEqual('https://github.com/user/repo/blob/master/README.md?plain=1#L5-L7',
+                         parse_result.get_source_url('README.md', 'master', 5, 7))
+        self.assertEqual('https://github.com/user/repo/blame/master/README.md',
+                         parse_result.get_blame_url('README.md', 'master'))
+        self.assertEqual('https://github.com/user/repo/blame/master/README.md?plain=1#L5',
+                         parse_result.get_blame_url('README.md', 'master', 5))
+        self.assertEqual('https://github.com/user/repo/blame/master/README.md?plain=1#L5-L7',
+                         parse_result.get_blame_url('README.md', 'master', 5, 7))
+
     def test_url_space(self):
         parse_result = RepositoryParser('git@github.com:user/repo.git')
         self.assertEqual('ssh', parse_result.scheme)
@@ -990,6 +1011,27 @@ class RepoParserGitLab(TestCase):
         self.assertEqual('https://gitlab.selfhost.io/user/repo/-/blame/master/README.md?plain=1#L5',
                          parse_result.get_blame_url('README.md', 'master', 5))
         self.assertEqual('https://gitlab.selfhost.io/user/repo/-/blame/master/README.md?plain=1#L5-7',
+                         parse_result.get_blame_url('README.md', 'master', 5, 7))
+
+    def test_ssh_groups_with_port(self):
+        parse_result = RepositoryParser('ssh://git@gitlab.com:2222/group1/group2/repo.git')
+        self.assertEqual('ssh', parse_result.scheme)
+        self.assertEqual('gitlab.com', parse_result.domain)
+        self.assertEqual('git', parse_result.logon_user)
+        self.assertEqual(None, parse_result.logon_password)
+        self.assertEqual('group1/group2', parse_result.owner)
+        self.assertEqual('repo', parse_result.repo_name)
+        self.assertEqual('https://gitlab.com/group1/group2/repo/-/blob/master/README.md',
+                         parse_result.get_source_url('README.md', 'master'))
+        self.assertEqual('https://gitlab.com/group1/group2/repo/-/blob/master/README.md?plain=1#L5',
+                         parse_result.get_source_url('README.md', 'master', 5))
+        self.assertEqual('https://gitlab.com/group1/group2/repo/-/blob/master/README.md?plain=1#L5-7',
+                         parse_result.get_source_url('README.md', 'master', 5, 7))
+        self.assertEqual('https://gitlab.com/group1/group2/repo/-/blame/master/README.md',
+                         parse_result.get_blame_url('README.md', 'master'))
+        self.assertEqual('https://gitlab.com/group1/group2/repo/-/blame/master/README.md?plain=1#L5',
+                         parse_result.get_blame_url('README.md', 'master', 5))
+        self.assertEqual('https://gitlab.com/group1/group2/repo/-/blame/master/README.md?plain=1#L5-7',
                          parse_result.get_blame_url('README.md', 'master', 5, 7))
 
     def test_ssh_groups(self):


### PR DESCRIPTION
  - SSH port treated as owner: For SSH URLs with an explicit port (e.g. ssh://git@host:2222/owner/repo.git), the colon-to-slash regex converted host:2222 into host/2222, putting the port number into the path
  where it was interpreted as the owner. Added a (?!\d) negative lookahead so numeric ports are left for urlparse to handle correctly.
  - Multi-level paths dropped middle segments: For URLs with nested group paths like ssh://git@host/group/subgroup/repo.git, only the first and last path segments were kept, silently dropping everything in
  between. Changed the default to owner = '/'.join(split_path[:-1]) so all intermediate segments are preserved. This was previously only handled for gitlab — now it works for all hosts, including user-defined
  ones.
  - Simplified netloc parsing: Replaced manual netloc.split('@') with urlparse properties (hostname, username, password), which correctly strips ports from the domain.
  - Removed the RhodeCode SSH workaround that skipped the first path segment (it was compensating for the port-as-path bug).
  - Added explicit owner = split_path[0] to codebase and phabricator overrides, and fixed the sourceforge condition to check split_path[0] instead of self.owner.

